### PR TITLE
Fix: Ensure hex color detection is case-insensitive

### DIFF
--- a/src/Palette.php
+++ b/src/Palette.php
@@ -36,7 +36,7 @@ class Palette
 
     public function determineType(string $value): string
     {
-        if (preg_match('/(^#?[a-f0-9]{6})/', $value) === 1) {
+        if (preg_match('/^#?[a-fA-F0-9]{6}$/', $value) === 1) {
             return 'hex';
         } elseif (preg_match("/(\d{1,3},\s\d{1,3},\s\d{1,3})/", $value) === 1) {
             return 'rgb';


### PR DESCRIPTION
This PR updates the determineType method to ensure hex color detection is case-insensitive. 

This resolves an issue where uppercase hex colors like `#FF0000` were incorrectly classified as 'class'.

### example

`ColorPickerSelect::make('color')
            ->colors([
                 'Red'=> '#FF0000', 
                'Blue' => '#0000FF', ]);`
                
### before
![36](https://github.com/user-attachments/assets/bae6ce97-a4b3-4420-a869-87d85ccef96c)

### After
![32](https://github.com/user-attachments/assets/d68778f2-0554-453d-9139-c6d2dc65368c)
