### PR TITLE
docs: add docs/ for the documentation hub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 build
 composer.lock
 coverage
-docs
 node_modules
 phpunit.xml
 phpstan.neon

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,139 @@
+---
+title: Components
+description: The ColorPicker and ColorPickerSelect form fields, the ColorEntry infolist entry, and the color options they share.
+---
+
+# Components
+
+Palette provides two form components and one infolist component. The two form fields take exactly the same color options and differ only in how they present them.
+
+## ColorPicker
+
+A row of clickable swatches:
+
+```php
+use Awcodes\Palette\Forms\Components\ColorPicker;
+use Filament\Support\Colors\Color;
+
+ColorPicker::make('color')
+    ->colors([
+        'indigo' => Color::Indigo,
+        'badass' => Color::hex('#bada55'),
+        'salmon' => '#fa8072',
+        'bg-gradient-secondary' => 'bg-gradient-secondary',
+    ])
+    ->shades([
+        'badass' => 300,
+    ])
+    ->labels([
+        'bg-gradient-secondary' => 'Gradient Secondary',
+    ])
+    ->size('sm')
+    ->withBlack(swap: '#111111')
+    ->withWhite(swap: '#f5f5f5'),
+```
+
+## ColorPickerSelect
+
+The same palette as a dropdown, with a swatch rendered beside each option. Useful where a row of swatches would be too wide, or where the palette is long enough that scanning a list is easier.
+
+```php
+use Awcodes\Palette\Forms\Components\ColorPickerSelect;
+use Filament\Support\Colors\Color;
+
+ColorPickerSelect::make('color')
+    ->colors([
+        'indigo' => Color::Indigo,
+        'badass' => Color::hex('#bada55'),
+        'salmon' => '#fa8072',
+        'bg-gradient-secondary' => 'bg-gradient-secondary',
+    ])
+    ->shades([
+        'badass' => 300,
+    ])
+    ->labels([
+        'bg-gradient-secondary' => 'Gradient Secondary',
+    ])
+    ->withBlack(swap: '#111111')
+    ->withWhite(swap: '#f5f5f5'),
+```
+
+Options are sorted alphabetically by label, regardless of the order you define them in.
+
+> [!NOTE]
+> `ColorPickerSelect` does not support `size()`. Sizing applies to swatch grids, not to select options.
+
+## ColorEntry
+
+Renders a stored color as a swatch in an infolist:
+
+```php
+use Awcodes\Palette\Infolists\Components\ColorEntry;
+
+ColorEntry::make('color')
+    ->size('sm'),
+```
+
+## Defining colors
+
+### colors()
+
+Pass an array keyed by the name you want stored. Values may be:
+
+- A Filament color object — `Color::Indigo`, or `Color::hex('#bada55')`. These carry a full shade range.
+- A plain hex string — `'#fa8072'`. Stored as-is, with no shades.
+- A CSS class name — `'bg-gradient-secondary'`. Useful for gradients and anything else a single color value cannot express.
+
+If you never call `colors()`, Palette falls back to the colors registered with your panel via `FilamentColor::getColors()`. Passing an explicit array is usually what you want, since the registered set includes Filament's own semantic colors.
+
+### shades()
+
+Filament color objects contain a range of shades. `shades()` selects which one to use, keyed by color:
+
+```php
+->shades([
+    'badass' => 300,
+])
+```
+
+Any color you do not list uses shade `500`. A color given as a plain hex string or a CSS class has no shades at all, so an entry for it has no effect.
+
+> [!NOTE]
+> Shades only work with Filament color objects.
+
+### labels()
+
+By default, a color's label is derived from its key — title-cased, with dashes replaced by spaces, so `bg-gradient-secondary` becomes "Bg Gradient Secondary". Override it where that reads badly:
+
+```php
+->labels([
+    'bg-gradient-secondary' => 'Gradient Secondary',
+])
+```
+
+### withWhite() and withBlack()
+
+Black and white are not part of Filament's registered colors, so Palette adds them on request. Both are appended to the end of the palette, after your own colors:
+
+```php
+->withWhite()
+->withBlack(),
+```
+
+They default to `#ffffff` and `#000000`. Pass `swap` to substitute a softer value — useful when pure black and white are not in your design system:
+
+```php
+->withBlack(swap: '#111111')
+->withWhite(swap: '#f5f5f5'),
+```
+
+### size()
+
+Available on `ColorPicker` and `ColorEntry`. Accepts `xs`, `sm`, `md`, `lg` or `xl`, and defaults to `md`:
+
+```php
+->size('sm'),
+```
+
+> [!WARNING]
+> Any other value throws an exception rather than falling back to the default, so avoid computing the size from user input without validating it first.

--- a/docs/docs.yml
+++ b/docs/docs.yml
@@ -1,0 +1,10 @@
+version: 1
+
+title: Palette
+
+navigation:
+  - index
+  - installation
+  - components
+  - storing-colors
+  - styling

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,35 @@
+---
+title: Palette
+description: A color picker field for Filament forms that offers a preset palette of colors rather than a free-form picker.
+---
+
+# Palette
+
+Palette gives Filament forms a color picker restricted to a palette you define. Instead of a free-form picker that can produce any value, the user chooses from a fixed set of swatches — your brand colors, your theme's registered colors, or whatever list you pass in.
+
+It is for content that has to stay on-brand. When an editor picks a heading color or a section background, you usually want them choosing from the design system rather than typing a hex value.
+
+## What's included
+
+Palette ships three components:
+
+- **`ColorPicker`** — a row of clickable color swatches, for forms.
+- **`ColorPickerSelect`** — the same palette as a searchable dropdown with a swatch beside each option, for forms where a row of swatches would be too wide.
+- **`ColorEntry`** — renders a stored color as a swatch, for infolists.
+
+All three read the same color definitions and understand the same stored format.
+
+## Compatibility
+
+| Package version | Filament version |
+|---|---|
+| 1.x | 3.x |
+| 2.x | 4.x |
+| 3.x | 4.x and 5.x |
+
+## Where to go next
+
+- [Installation](installation.md) — install the package and register its views with your theme.
+- [Components](components.md) — the fields and entry, and the color options they share.
+- [Storing colors](storing-colors.md) — how the selected color is saved, and how to store just the key instead.
+- [Styling](styling.md) — the CSS classes available for customization.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,51 @@
+---
+title: Installation
+description: Install Palette, register its views with your Filament theme, and publish the config file.
+---
+
+# Installation
+
+## Install the package
+
+Install Palette via Composer:
+
+```bash
+composer require awcodes/palette
+```
+
+## Register the views with your theme
+
+Palette ships Blade views with Tailwind classes, so your theme has to scan them or the components will render unstyled.
+
+> [!IMPORTANT]
+> If you have not set up a custom theme and are using Filament Panels, follow the [Filament custom theme instructions](https://filamentphp.com/docs/4.x/styling/overview#creating-a-custom-theme) first.
+
+Once you have a custom theme, add Palette's views to your theme's CSS file — or your app's CSS file if you are using the standalone packages:
+
+```css
+@source '../../../../vendor/awcodes/palette/resources/**/*.blade.php';
+```
+
+The path is relative to the CSS file it appears in. The four levels of `../` assume the default theme location at `resources/css/filament/admin/theme.css`; adjust it if your theme lives elsewhere.
+
+## Publish the config file
+
+Palette works without publishing its config. Publish it only if you want to change a default:
+
+```bash
+php artisan vendor:publish --tag="palette-config"
+```
+
+The published file has a single option:
+
+```php
+return [
+    'store_as_key' => false,
+];
+```
+
+Setting `store_as_key` to `true` makes every Palette field store just the color's key instead of the full color array. See [Storing colors](storing-colors.md) for what that changes.
+
+## Next
+
+With the package installed and your theme scanning its views, add a component to a form — see [Components](components.md).

--- a/docs/storing-colors.md
+++ b/docs/storing-colors.md
@@ -1,0 +1,76 @@
+---
+title: Storing colors
+description: How Palette saves a selected color, how to cast the column, and how to store only the color's key.
+---
+
+# Storing colors
+
+## Casting the column
+
+By default Palette stores the selected color as an array, so the column must be cast to `array` or `json` on your model:
+
+```php
+protected $casts = [
+    'content' => 'array', // or 'json'
+];
+```
+
+## The stored shape
+
+A saved color looks like this:
+
+```php
+[
+    'key' => 'primary',
+    'property' => '--primary-500',
+    'label' => 'Primary',
+    'type' => 'rgb',
+    'value' => '238, 246, 213',
+]
+```
+
+Each key is derived as follows:
+
+| Key | Meaning |
+|---|---|
+| `key` | The array key you gave the color in `colors()`. |
+| `property` | A CSS custom property name — `--{key}` for a flat color, or `--{key}-{shade}` when the color came from a Filament color object. |
+| `label` | The label from `labels()`, or the title-cased key. |
+| `type` | One of `hex`, `rgb`, `oklch` or `class`, detected from the value. |
+| `value` | The resolved color value at the selected shade. |
+
+Storing the whole array means you can render the color without looking anything up — you have the value, a property name to bind it to, and a label to display.
+
+The `class` type is what makes CSS-class colors work. A value like `bg-gradient-secondary` is not a color at all, so Palette marks it as a class and you apply it as one rather than as a value.
+
+## Storing only the key
+
+If you would rather store a plain string, use `storeAsKey()` on the field:
+
+```php
+use Awcodes\Palette\Forms\Components\ColorPicker;
+
+ColorPicker::make('color')
+    ->storeAsKey(),
+```
+
+The column then holds `'primary'` rather than the full array, so it does not need an `array` cast. You give up the resolved value, property and label — you will need to resolve the key against your palette yourself when rendering.
+
+To apply it across every Palette field, set it in the config file instead:
+
+```php
+// config/palette.php
+return [
+    'store_as_key' => true,
+];
+```
+
+> [!NOTE]
+> The field-level modifier can only turn this behaviour on, not off. `shouldStoreAsKey()` returns `true` if the field opts in, and otherwise falls back to the config value — so when `store_as_key` is `true` globally, passing `storeAsKey(false)` on an individual field will not switch it back to storing the full array.
+
+## Reading a stored color
+
+> [!WARNING]
+> `ColorEntry` requires the full array shape. It reads `label`, `value` and `type` off the stored state directly, so pointing it at a column written with `storeAsKey()` will fail rather than render a swatch.
+
+If you store keys and still want a swatch in an infolist, resolve the key back to a color yourself — look it up in the same palette you passed to the field — and render it, or keep the full array for records that need to be displayed this way. See [Components](components.md).

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -1,0 +1,44 @@
+---
+title: Styling
+description: The CSS classes Palette exposes for customizing the picker, the select options and the infolist entry.
+---
+
+# Styling
+
+Palette puts a stable class on each part of its markup so you can restyle the components from your theme without overriding the views.
+
+## ColorPicker
+
+| Class | Applies to |
+|---|---|
+| `palette-color-picker` | The container holding the swatches. |
+| `palette-color-picker-item` | Each individual swatch. |
+| `palette-color-picker-item-active` | The currently selected swatch. |
+
+## ColorPickerSelect
+
+| Class | Applies to |
+|---|---|
+| `palette-select-option` | Each option in the dropdown — the swatch and its label. |
+
+## ColorEntry
+
+| Class | Applies to |
+|---|---|
+| `palette-entry-item` | The swatch rendered in an infolist. |
+
+## Example
+
+Because these classes sit alongside Palette's own utility classes, target them from your theme's CSS:
+
+```css
+.palette-color-picker {
+    gap: 0.5rem;
+}
+
+.palette-color-picker-item-active {
+    outline: 2px solid var(--primary-600);
+}
+```
+
+Sizing is better handled through the `size()` modifier than in CSS — see [Components](components.md).


### PR DESCRIPTION
Adds a structured `docs/` directory so this package can be published to the documentation hub.

- Stops `.gitignore` from ignoring `docs`. The package skeleton ignored it, which would have made the whole directory invisible to git silently.
- Adds 5 pages: index, installation, components, storing-colors, styling.

The two form fields share their entire color API, so rather than duplicating it the way the README does, `components.md` documents `ColorPicker`, `ColorPickerSelect` and `ColorEntry` together with one pass over `colors()`, `shades()`, `labels()`, `withWhite()`/`withBlack()` and `size()`.

Everything is verified against the source — the stored array shape and how each key is derived against `Palette::buildColor()`, the fallbacks (`colors()` to `FilamentColor::getColors()`, `shades()` to 500, labels to the title-cased key) against `HasColors`, the size whitelist and its exception against `HasSize`, and the style hook class names against the Blade views. The README is unchanged.

Docs are version-scoped by branch, so these are the 3.x docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)